### PR TITLE
Set the actual process workingDirectory if the working-directory parameter is given

### DIFF
--- a/eslint.js
+++ b/eslint.js
@@ -99,6 +99,9 @@ const eslintAnnotations = async (
 async function run() {
     const eslintDirectory = process.env['INPUT_ESLINT-LIB'];
     const workingDirectory = process.env['INPUT_CUSTOM-WORKING-DIRECTORY'];
+    if (workingDirectory != null && workingDirectory.trim() !== '') {
+        process.chdir(workingDirectory);
+    }
     const subtitle = process.env['INPUT_CHECK-RUN-SUBTITLE'];
     if (!eslintDirectory) {
         /* flow-uncovered-block */
@@ -117,7 +120,7 @@ async function run() {
         return;
     }
 
-    const files = await gitChangedFiles(baseRef, workingDirectory || '.');
+    const files = await gitChangedFiles(baseRef, '.');
     const validExt = ['.js', '.jsx', '.mjs', '.ts', '.tsx'];
     const jsFiles = files.filter(file => validExt.includes(path.extname(file)));
 


### PR DESCRIPTION
## Summary:
I think this is needed for eslint plugin resolution to work properly.
see https://github.com/Khan/mobile/pull/1558/checks?check_run_id=2384694521 for currently failing action


Issue: none

## Test plan:
:fingers-crossed:
use it in mobile, see if it fixes the issue