### PR TITLE
Add "run-all-if-changed" config option

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -13,6 +13,9 @@ inputs:
   check-run-subtitle:
     required: false
     description: 'A subtitle to add to the check run when annotations are passed back to avoid overwriting each other'
+  run-all-if-changed:
+    required: false
+    description: 'Comma-separated list of files which, if changed, trigger a re-check of all files'
 branding:
   icon: check-circle
   color: red

--- a/eslint.js
+++ b/eslint.js
@@ -132,8 +132,11 @@ async function run() {
         return;
     }
 
+    const current = process.pwd();
     const files = await gitChangedFiles(baseRef, '.');
-    const shouldRunAll = runAllIfChanged.some(name => files.some(file => file === name));
+    const shouldRunAll = runAllIfChanged.some(name =>
+        files.some(file => path.relative(current, file) === name),
+    );
     const validExt = ['.js', '.jsx', '.mjs', '.ts', '.tsx'];
     const jsFiles = shouldRunAll
         ? // Use globs to get all files
@@ -141,8 +144,8 @@ async function run() {
         : files.filter(file => validExt.includes(path.extname(file)));
 
     if (!jsFiles.length) {
-        core.info(files); // flow-uncovered-line
         core.info('No JavaScript files changed'); // flow-uncovered-line
+        core.info(`Changed files:\n - ${files.join('\n - ')}`); // flow-uncovered-line
         return;
     }
     const annotations = await eslintAnnotations(workingDirectory || '.', eslintDirectory, jsFiles);

--- a/eslint.js
+++ b/eslint.js
@@ -132,7 +132,7 @@ async function run() {
         return;
     }
 
-    const current = process.pwd();
+    const current = process.cwd();
     const files = await gitChangedFiles(baseRef, '.');
     const shouldRunAll = runAllIfChanged.some(name =>
         files.some(file => path.relative(current, file) === name),

--- a/eslint.js
+++ b/eslint.js
@@ -139,8 +139,8 @@ async function run() {
     );
     const validExt = ['.js', '.jsx', '.mjs', '.ts', '.tsx'];
     const jsFiles = shouldRunAll
-        ? // Use globs to get all files
-          validExt.map(ext => `**/*${ext}`)
+        ? // Get all files
+          ['.']
         : files.filter(file => validExt.includes(path.extname(file)));
 
     if (!jsFiles.length) {

--- a/eslint.js
+++ b/eslint.js
@@ -141,6 +141,7 @@ async function run() {
         : files.filter(file => validExt.includes(path.extname(file)));
 
     if (!jsFiles.length) {
+        core.info(files); // flow-uncovered-line
         core.info('No JavaScript files changed'); // flow-uncovered-line
         return;
     }

--- a/eslint.js
+++ b/eslint.js
@@ -132,7 +132,7 @@ async function run() {
         return;
     }
 
-    const current = process.cwd();
+    const current = path.resolve(workingDirectory || '');
     const files = await gitChangedFiles(baseRef, '.');
     const shouldRunAll = runAllIfChanged.some(name =>
         files.some(file => path.relative(current, file) === name),


### PR DESCRIPTION
## Summary:
This will allow us to recheck all files when eslint.config.js changes or package.json.

Issue: https://khanacademy.atlassian.net/browse/FEI-3519

## Test plan:
try it out on a test repo: https://github.com/Khan/actions-trigger-test-repo/pull/3/checks
it works!
whereas without this config option (https://github.com/Khan/actions-trigger-test-repo/pull/4) no tests are run b/c the action doesn't see any changed js files